### PR TITLE
fix: refresh rank page

### DIFF
--- a/lib/pages/rank/controller.dart
+++ b/lib/pages/rank/controller.dart
@@ -28,7 +28,7 @@ class RankController extends GetxController with GetTickerProviderStateMixin {
   void onRefresh() {
     int index = tabController.index;
     var ctr = tabsCtrList[index];
-    ctr().onRefresh();
+    ctr.onRefresh();
   }
 
   void animateToTop() {


### PR DESCRIPTION
修复双击底栏无法刷新分区页面