### PR TITLE
mod: 更改alpha版本号格式

### DIFF
--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Get previous workflow run
         id: get_previous_run
         env:
-          GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # TODO: 获取上一个workflow run运行状态以等待其artifact
           workflow_runs=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
@@ -65,7 +65,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build_info
-          github-token: $${{ secrets.GIT_TOKEN }}
+          github-token: $${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ steps.get_previous_run.outputs.previous_run_id }}
 
       - name: 生成alpha版本号

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -41,23 +41,24 @@ jobs:
           last_commit_hash=$(git log -1 --pretty="%H" --first-parent)
           echo "included_commits=$included_commits" >> $GITHUB_OUTPUT
           echo "last_commit_hash=$last_commit_hash" >> $GITHUB_OUTPUT
-      # TODO 语法可能已过时
+
       - name: Get previous workflow run
         id: get_previous_run
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
         run: |
           workflow_runs=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${{ env.id }}/runs?status=completed&per_page=2")
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/build-alpha.yml/runs?status=completed&per_page=2")
           previous_run_id=$(echo $workflow_runs | jq -r '.workflow_runs[1].id')
           echo "Previous run ID: $previous_run_id"
-          echo "previous_run_id=$previous_run_id" >> $GITHUB_ENV
+          echo "previous_run_id=$previous_run_id" >> $GITHUB_OUTPUT
 
       - name: 从artifact获取上次构建信息
         uses: actions/download-artifact@v4
         with:
           name: build_info
-          run-id: ${{ env.previous_run_id }}
+          github-token: $${{ secrets.GIT_TOKEN }}
+          run-id: ${{ steps.get_previous_run.outputs.previous_run_id }}
 
       - name: 生成alpha版本号
         id: update_version

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -51,8 +51,14 @@ jobs:
           workflow_runs=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/actions/workflows/build-alpha.yml/runs?status=completed&per_page=2")
           previous_run_id=$(echo $workflow_runs | jq -r '.workflow_runs[1].id')
+          previous_run_success=0
+          if (echo $workflow_runs | jq -r '.workflow_runs[1].conclusion' | grep -q 'success'); then
+            previous_run_success=1
+          fi
           echo "Previous run ID: $previous_run_id"
           echo "previous_run_id=$previous_run_id" >> $GITHUB_OUTPUT
+          echo "Previous run success: $previous_run_success"
+          echo "Previous run success=$previous_run_success" >> $GITHUB_OUTPUT
 
       - name: 从artifact获取上次构建信息
         if: ${{ ! inputs.build_num }}
@@ -80,15 +86,12 @@ jobs:
             alpha_or_pre=alpha
           fi
 
-          # TODO: 如果上次workflow run失败，且与当前版本号一致，不递增build_num。
-          build_num=0
+          # 如果上次workflow run失败，且与当前版本号一致，不递增build_num。
+          build_num=1
           if [[ -n "${{ inputs.build_num }}" ]]; then
             build_num=${{ inputs.build_num }}
-          else
-            if [[ $(yq -r .version build_info.yml) == $version_name ]]; then
-              build_num=$(yq -r .build_num build_info.yml)
-            fi
-            let ++build_num
+          elif [[ $(yq -r .version build_info.yml) == $version_name ]]; then
+            let build_num=$(yq -r .build_num build_info.yml)+${{ steps.get_previous_run.outputs.previous_run_success }}
           fi
 
           echo "new_version=${version_name}-${alpha_or_pre}.${build_num}+${version_code}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build_info
-          github-token: $${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ steps.get_previous_run.outputs.previous_run_id }}
 
       - name: 生成alpha版本号

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -54,6 +54,7 @@ jobs:
           echo "previous_run_id=$previous_run_id" >> $GITHUB_OUTPUT
 
       - name: 从artifact获取上次构建信息
+        if: ! ${{ inputs.build_num }}
         uses: actions/download-artifact@v4
         with:
           name: build_info

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -71,32 +71,26 @@ jobs:
             echo "Neither build_info.yml exists nor specified build_num manually!"
             exit 1
           fi
-
+          
+          # pubspec.yml中版本号比tag新，则发布pre版，否则发布pre版
+          alpha_or_pre=pre
           if (echo $last_tag | grep $version_name); then
-            # 版本号一致，发行alpha版
-            # TODO alpha_num可能无法等于1
-            alpha_num=0
-            if [[ -n "${{ inputs.build_num }}" ]]; then
-              alpha_num=${{ inputs.build_num }}
-            else
-              let alpha_num=$(yq -r .build_num build_info.yml)+1
-            fi
-            echo "new_version=${version_name}-alpha.${alpha_num}+${version_code}" >> $GITHUB_OUTPUT
-            echo "new_build_num=$alpha_num" >> $GITHUB_OUTPUT
-          else
-            # 版本号不存在，发行pre版
-            pre_num=0
-            if [[ -n "${{ inputs.build_num }}" ]]; then
-              pre_num=${{ inputs.build_num }}
-            else
-              if [[ $(yq -r .version build_info.yml) == $version_name ]]; then
-                pre_num=$(yq -r .build_num build_info.yml)
-              fi
-              let ++pre_num
-            fi
-            echo "new_version=${version_name}-pre.${pre_num}+${version_code}" >> $GITHUB_OUTPUT
-            echo "new_build_num=$pre_num" >> $GITHUB_OUTPUT
+            alpha_or_pre=alpha
           fi
+
+          build_num=0
+          # 手动指定build_num优先于文件
+          if [[ -n "${{ inputs.build_num }}" ]]; then
+            build_num=${{ inputs.build_num }}
+          else
+            if [[ $(yq -r .version build_info.yml) == $version_name ]]; then
+              build_num=$(yq -r .build_num build_info.yml)
+            fi
+            let ++build_num
+          fi
+
+          echo "new_version=${version_name}-${alpha_or_pre}.${build_num}+${version_code}" >> $GITHUB_OUTPUT
+          echo "new_build_num=$alpha_num" >> $GITHUB_OUTPUT                                      
 
       - name: 生成新build_info.yml
         run: |

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -3,9 +3,9 @@ on:
   workflow_dispatch:
     inputs:
       build_num:
-        require: true
+        required: true
         type: choice
-        default: 1
+        default: "1"
         options: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 114514]
 
   push:
@@ -54,7 +54,7 @@ jobs:
           echo "previous_run_id=$previous_run_id" >> $GITHUB_ENV
 
       - name: 从artifact获取上次构建信息
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build_info
           run-id: ${{ env.previous_run_id }}
@@ -194,7 +194,7 @@ jobs:
 
       - name: 上传至artifact (${{ matrix.target_platform }})
         if: startsWith(matrix.target_platform, 'android')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: PiliPalaX-alpha
           path: |
@@ -202,7 +202,7 @@ jobs:
 
       - name: 上传至artifact (iOS)
         if: matrix.target_platform == 'iOS'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: 
           name: PiliPalaX-alpha
           path: |
@@ -216,7 +216,7 @@ jobs:
     
     steps:
       - name: 从artifact下载
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: PiliPalaX-alpha
           path: ./PiliPalaX-alpha

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -95,10 +95,11 @@ jobs:
 
       - name: 生成新build_info.yml
         run: |
+          ls -l
           version=$(yq -er .version pubspec.yml | cut -d "+" -f 1)
           build_num=${{ steps.update_version.outputs.new_build_num}}
           
-          rm -r build_info.yml
+          rm -f build_info.yml
           cat << EOF > build_info.yml
           version: $version
           build_num: $build_num

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -47,6 +47,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
         run: |
+          # TODO: 获取上一个workflow run运行状态以等待其artifact
           workflow_runs=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/actions/workflows/build-alpha.yml/runs?status=completed&per_page=2")
           previous_run_id=$(echo $workflow_runs | jq -r '.workflow_runs[1].id')
@@ -79,8 +80,8 @@ jobs:
             alpha_or_pre=alpha
           fi
 
+          # TODO: 如果上次workflow run失败，且与当前版本号一致，不递增build_num。
           build_num=0
-          # 手动指定build_num优先于文件
           if [[ -n "${{ inputs.build_num }}" ]]; then
             build_num=${{ inputs.build_num }}
           else
@@ -212,7 +213,7 @@ jobs:
         if: startsWith(matrix.target_platform, 'android')
         uses: actions/upload-artifact@v4
         with:
-          name: PiliPalaX-alpha
+          name: PiliPalaX-${{ matrix.target_platform }}
           path: |
             build/app/outputs/flutter-apk/Pili-*.apk
 
@@ -220,7 +221,7 @@ jobs:
         if: matrix.target_platform == 'iOS'
         uses: actions/upload-artifact@v4
         with: 
-          name: PiliPalaX-alpha
+          name: PiliPalaX-iOS
           path: |
             build/Pili-*.ipa
 
@@ -234,7 +235,6 @@ jobs:
       - name: 从artifact下载
         uses: actions/download-artifact@v4
         with:
-          name: PiliPalaX-alpha
           path: ./PiliPalaX-alpha
 
       - name: 发送到Telegram频道
@@ -246,6 +246,6 @@ jobs:
           api_hash: ${{ secrets.TELEGRAM_API_HASH }}
           large_file: true
           method: sendFile
-          path: PiliPalaX-alpha/*
+          path: PiliPalaX-alpha/Pili-*
           parse_mode: Markdown
           context: "*v${{ needs.prepare_publish_info.outputs.new_version }}:*\n${{ fromJson(needs.prepare_publish_info.outputs.included_commits) }}"      

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -41,7 +41,7 @@ jobs:
           last_commit_hash=$(git log -1 --pretty="%H" --first-parent)
           echo "included_commits=$included_commits" >> $GITHUB_OUTPUT
           echo "last_commit_hash=$last_commit_hash" >> $GITHUB_OUTPUT
-
+      # TODO 语法可能已过时
       - name: Get previous workflow run
         id: get_previous_run
         env:
@@ -73,6 +73,7 @@ jobs:
 
           if (echo $last_tag | grep $version_name); then
             # 版本号一致，发行alpha版
+            # TODO alpha_num可能无法等于1
             alpha_num=0
             if [[ -n "${{ inputs.build_num }}" ]]; then
               alpha_num=${{ inputs.build_num }}
@@ -80,6 +81,7 @@ jobs:
               let alpha_num=$(yq -r .build_num build_info.yml)+1
             fi
             echo "new_version=${version_name}-alpha.${alpha_num}+${version_code}" >> $GITHUB_OUTPUT
+            echo "new_build_num=$alpha_num" >> $GITHUB_OUTPUT
           else
             # 版本号不存在，发行pre版
             pre_num=0
@@ -92,7 +94,25 @@ jobs:
               let ++pre_num
             fi
             echo "new_version=${version_name}-pre.${pre_num}+${version_code}" >> $GITHUB_OUTPUT
+            echo "new_build_num=$pre_num" >> $GITHUB_OUTPUT
           fi
+
+      - name: 生成新build_info.yml
+        run: |
+          version=$(yq -er .version pubspec.yml | cut -d "+" -f 1)
+          build_num=${{ steps.update_version.outputs.new_build_num}}
+          
+          rm -r build_info.yml
+          cat << EOF > build_info.yml
+          version: $version
+          build_num: $build_num
+          EOF
+
+      - name: 上传build_info.yml
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_info
+          path: ./build_info.yml
 
   build_matrix:
     name: Build CI (${{ matrix.target_platform }})

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -12,14 +12,14 @@ on:
       - '!.github/workflows/build-alpha.yml'
 
 jobs:
-  update_version:
-    name: Read latest version
+  prepare_publish_info:
+    name: Prepare publish info
     runs-on: ubuntu-latest
 
     outputs:
-      # 定义输出变量 version，以便在其他job中引用
-      new_version: ${{ steps.update-version.outputs.new_version }}
-      last_commit: ${{ steps.get-last-commit.outputs.last_commit }}
+      new_version: ${{ steps.update_version.outputs.new_version }}
+      included_commits: ${{ steps.analyze_push_event.outputs.included_commits }}
+      last_commit_hash: ${{ steps.analyze_push_event.outputs.last_commit_hash }}
 
     steps:
       - name: Checkout code
@@ -28,13 +28,15 @@ jobs:
           fetch-depth: 0
 
       - name: 获取最后一次提交
-        id: get-last-commit
+        id: analyze_push_event
         run: |
-          last_commit=$(git log -1 --pretty="%h %s" --first-parent)
-          echo "last_commit=$last_commit" >> $GITHUB_OUTPUT
+          included_commits=$(git log ${{ github.event.before }}..HEAD --pretty="%h %s" --first-parent | jq -Rs '.')
+          last_commit_hash=$(git log -1 --pretty="%H" --first-parent)
+          echo "included_commits=$included_commits" >> $GITHUB_OUTPUT
+          echo "last_commit_hash=$last_commit_hash" >> $GITHUB_OUTPUT
 
       - name: 生成alpha版本号
-        id: update-version
+        id: update_version
         run: |
           version_name=$(yq e .version pubspec.yaml | cut -d "+" -f 1)
           last_tag=$(git tag --sort=committerdate | tail -1)
@@ -43,7 +45,7 @@ jobs:
             echo "Illegal tag! ($last_tag)"
             exit 1
           elif (echo $last_tag | grep -v $version_name); then
-            echo "No tags for current version in the repo, please add one manually."
+            echo "No tags for current version ($version_name) in the repo, please add one manually."
             exit 1
           fi
 
@@ -53,7 +55,7 @@ jobs:
 
   build_matrix:
     name: Build CI (${{ matrix.target_platform }})
-    needs: update_version
+    needs: prepare_publish_info
     runs-on: ${{ matrix.build_os }}
     strategy:
       matrix:
@@ -104,7 +106,7 @@ jobs:
       - name: 更新版本号
         id: version
         run: |
-          yq ".version=\"${{ needs.update_version.outputs.new_version }}\"" pubspec.yaml > tmp.yaml
+          yq ".version=\"${{ needs.prepare_publish_info.outputs.new_version }}\"" pubspec.yaml > tmp.yaml
           mv tmp.yaml pubspec.yaml
 
       - name: flutter build apk (universal)
@@ -145,7 +147,7 @@ jobs:
         if: matrix.target_platform == 'iOS'
         run: |
           for file in app.ipa; do
-            new_file_name="build/Pili-${{ needs.update_version.outputs.new_version }}.ipa"
+            new_file_name="build/Pili-${{ needs.prepare_publish_info.outputs.new_version }}.ipa"
             mv "$file" "$new_file_name"
           done
 
@@ -168,7 +170,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     needs: 
-      - update_version
+      - prepare_publish_info
       - build_matrix
     
     steps:
@@ -179,7 +181,7 @@ jobs:
           path: ./PiliPalaX-alpha
 
       - name: 发送到Telegram频道
-        uses: xireiki/channel-post@v1.0.7
+        uses: xireiki/channel-post@v1.0.10
         with:
           bot_token: ${{ secrets.BOT_TOKEN }}
           chat_id: ${{ secrets.CHAT_ID }}
@@ -189,4 +191,4 @@ jobs:
           method: sendFile
           path: PiliPalaX-alpha/*
           parse_mode: Markdown
-          context: "*v${{ needs.update_version.outputs.new_version }}*\n${{ needs.update_version.outputs.last_commit }}"      
+          context: "*v${{ needs.prepare_publish_info.outputs.new_version }}:*\n${{ fromJson(needs.prepare_publish_info.outputs.included_commits) }}"      

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -1,6 +1,13 @@
 name: Build alpha
 on:
   workflow_dispatch:
+    inputs:
+      build_num:
+        require: true
+        type: choice
+        default: 1
+        options: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 114514]
+
   push:
     branches:
       - 'dev'
@@ -27,7 +34,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: 获取最后一次提交
+      - name: 解析push事件信息
         id: analyze_push_event
         run: |
           included_commits=$(git log ${{ github.event.before }}..HEAD --pretty="%h %s" --first-parent | jq -Rs '.')
@@ -35,23 +42,57 @@ jobs:
           echo "included_commits=$included_commits" >> $GITHUB_OUTPUT
           echo "last_commit_hash=$last_commit_hash" >> $GITHUB_OUTPUT
 
+      - name: Get previous workflow run
+        id: get_previous_run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
+        run: |
+          workflow_runs=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${{ env.id }}/runs?status=completed&per_page=2")
+          previous_run_id=$(echo $workflow_runs | jq -r '.workflow_runs[1].id')
+          echo "Previous run ID: $previous_run_id"
+          echo "previous_run_id=$previous_run_id" >> $GITHUB_ENV
+
+      - name: 从artifact获取上次构建信息
+        uses: actions/download-artifact@v3
+        with:
+          name: build_info
+          run-id: ${{ env.previous_run_id }}
+
       - name: 生成alpha版本号
         id: update_version
         run: |
-          version_name=$(yq e .version pubspec.yaml | cut -d "+" -f 1)
           last_tag=$(git tag --sort=committerdate | tail -1)
+          version_name=$(yq e .version pubspec.yaml | cut -d "+" -f 1)
+          version_code=$(echo $last_tag | cut -d "+" -f 2)
 
-          if (echo $last_tag | grep -v "+"); then
-            echo "Illegal tag! ($last_tag)"
-            exit 1
-          elif (echo $last_tag | grep -v $version_name); then
-            echo "No tags for current version ($version_name) in the repo, please add one manually."
+          if [[ ! -e build_info.yml && -z "${{ inputs.build_num }}" ]]; then
+            echo "Neither build_info.yml exists nor specified build_num manually!"
             exit 1
           fi
 
-          version_code=$(echo $last_tag | cut -d "+" -f 2)
-          datetime=$(date -u -d "8 hours" +%m%d%H%M)
-          echo "new_version=${version_name}-alpha.${datetime}+${version_code}" >> $GITHUB_OUTPUT
+          if (echo $last_tag | grep $version_name); then
+            # 版本号一致，发行alpha版
+            alpha_num=0
+            if [[ -n "${{ inputs.build_num }}" ]]; then
+              alpha_num=${{ inputs.build_num }}
+            else
+              let alpha_num=$(yq -r .build_num build_info.yml)+1
+            fi
+            echo "new_version=${version_name}-alpha.${alpha_num}+${version_code}" >> $GITHUB_OUTPUT
+          else
+            # 版本号不存在，发行pre版
+            pre_num=0
+            if [[ -n "${{ inputs.build_num }}" ]]; then
+              pre_num=${{ inputs.build_num }}
+            else
+              if [[ $(yq -r .version build_info.yml) == $version_name ]]; then
+                pre_num=$(yq -r .build_num build_info.yml)
+              fi
+              let ++pre_num
+            fi
+            echo "new_version=${version_name}-pre.${pre_num}+${version_code}" >> $GITHUB_OUTPUT
+          fi
 
   build_matrix:
     name: Build CI (${{ matrix.target_platform }})

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -50,7 +50,7 @@ jobs:
           # TODO: 获取上一个workflow run运行状态以等待其artifact
           workflow_runs=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/actions/workflows/build-alpha.yml/runs?status=completed&per_page=2")
-          previous_run_id=$(echo $workflow_runs | jq -r '.workflow_runs[1].id')
+          previous_run_id=$(echo $workflow_runs | jq -r '.workflow_runs[0].id')
           previous_run_success=0
           if (echo $workflow_runs | jq -r '.workflow_runs[1].conclusion' | grep -q 'success'); then
             previous_run_success=1

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -54,7 +54,7 @@ jobs:
           echo "previous_run_id=$previous_run_id" >> $GITHUB_OUTPUT
 
       - name: 从artifact获取上次构建信息
-        if: ! ${{ inputs.build_num }}
+        if: ${{ ! inputs.build_num }}
         uses: actions/download-artifact@v4
         with:
           name: build_info

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -73,7 +73,7 @@ jobs:
             exit 1
           fi
           
-          # pubspec.yml中版本号比tag新，则发布pre版，否则发布pre版
+          # pubspec.yaml中版本号比tag新，则发布pre版，否则发布pre版
           alpha_or_pre=pre
           if (echo $last_tag | grep $version_name); then
             alpha_or_pre=alpha
@@ -95,8 +95,7 @@ jobs:
 
       - name: 生成新build_info.yml
         run: |
-          ls -l
-          version=$(yq -er .version pubspec.yml | cut -d "+" -f 1)
+          version=$(yq -er .version pubspec.yaml | cut -d "+" -f 1)
           build_num=${{ steps.update_version.outputs.new_build_num}}
           
           rm -f build_info.yml

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -237,8 +237,6 @@ jobs:
     steps:
       - name: 从artifact下载
         uses: actions/download-artifact@v4
-        with:
-          path: ./PiliPalaX-alpha
 
       - name: 发送到Telegram频道
         uses: xireiki/channel-post@v1.0.10
@@ -249,6 +247,6 @@ jobs:
           api_hash: ${{ secrets.TELEGRAM_API_HASH }}
           large_file: true
           method: sendFile
-          path: PiliPalaX-alpha/Pili-*
+          path: PiliPalaX-*/*
           parse_mode: Markdown
           context: "*v${{ needs.prepare_publish_info.outputs.new_version }}:*\n${{ fromJson(needs.prepare_publish_info.outputs.included_commits) }}"      

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -58,7 +58,7 @@ jobs:
           echo "Previous run ID: $previous_run_id"
           echo "previous_run_id=$previous_run_id" >> $GITHUB_OUTPUT
           echo "Previous run success: $previous_run_success"
-          echo "Previous run success=$previous_run_success" >> $GITHUB_OUTPUT
+          echo "previous_run_success=$previous_run_success" >> $GITHUB_OUTPUT
 
       - name: 从artifact获取上次构建信息
         if: ${{ ! inputs.build_num }}

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -91,7 +91,7 @@ jobs:
           fi
 
           echo "new_version=${version_name}-${alpha_or_pre}.${build_num}+${version_code}" >> $GITHUB_OUTPUT
-          echo "new_build_num=$alpha_num" >> $GITHUB_OUTPUT                                      
+          echo "new_build_num=$build_num" >> $GITHUB_OUTPUT                                      
 
       - name: 生成新build_info.yml
         run: |


### PR DESCRIPTION
合并后首次自动运行的Actions会失败，这时需要指定初始`build_num`手动触发一次（Build alpha），之后通过push事件自动触发的Actions都会正常运行。
工作原理是从build-alpha.yml上次运行中的Artifact获取`version`和`build_num`参数，`version`会分别与最近的tag和`pubspec。yaml`中的语义版本号进行比对，当其与tag一致时，使用`alpha`版本号后缀，否则使用`pre`；当其与pubspec.yaml一致时，`++build_num`，否则`build_num=1`。版本号格式为`${version}-${alpha_or_pre}.${build_num}`。不会改变当前构建号。