### PR TITLE
fix: 复制动态链接时生成的链接有误

### DIFF
--- a/lib/pages/dynamics/widgets/author_panel.dart
+++ b/lib/pages/dynamics/widgets/author_panel.dart
@@ -168,7 +168,7 @@ class MorePanel extends StatelessWidget {
             leading: const Icon(Icons.share_outlined, size: 19),
             onTap: () async {
               await Share.share(
-                      '${HttpString.baseUrl}/dynamic/${item.idStr} UP主: ${item.modules.moduleAuthor.name}')
+                      '${HttpString.baseUrl}/opus/${item.idStr} UP主: ${item.modules.moduleAuthor.name}')
                   .whenComplete(() {});
             },
             minLeadingWidth: 0,

--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -532,6 +532,17 @@ class _VideoDetailPageState extends State<VideoDetailPage>
             elevation: 0,
             scrolledUnderElevation: 0,
             backgroundColor: Colors.transparent,
+            title: IconButton(
+              tooltip: '回到主页',
+              icon: const Icon(Icons.home),
+              onPressed: () async {
+                if (mounted) {
+                  popRouteStackContinuously = Get.currentRoute;
+                  Get.until((route) => route.isFirst);
+                  popRouteStackContinuously = "";
+                }
+              },
+            ),
             actions: [
               IconButton(
                 tooltip: '稍后再看',


### PR DESCRIPTION
如 Issue #237 所述，
在分享动态复制链接时，默认生成的链接格式为：
```
https://www.bilibili.com/dynamic/xxxxxxxxxxxxxx
```
新版哔哩哔哩动态页链接已修改为：
```
https://www.bilibili.com/opus/xxxxxxxxxxxxxx
```
且旧版页面已无法打开